### PR TITLE
ci: use GitHub token for GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,8 +30,8 @@ jobs:
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.JACONI_BOT_USERNAME }}
-          password: ${{ secrets.JACONI_BOT_GITHUB_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release
         env:


### PR DESCRIPTION
## Pull request checklist

_Pull request structure_
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *our main*.
- [x] Check the commits message styles matches our requested structure.

_Implementation checks_
- [ ] Tests for the changes have been added.
- [ ] Docs have been reviewed and added / updated if needed.
- [ ] Tests (`gradle clean check`) have passed locally any fixes were made for failures.
- [x] GitHub checks all pass (GH Actions, Sonar, Codecov).

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

We currently use a personal access token (classic) to push docker images. The new fine grained tokens do not support GHCR.

## What is the new behavior?

We use the default `GITHUB_TOKEN` to access GHCR.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No